### PR TITLE
Fix Logger.debug/1 undefined error

### DIFF
--- a/lib/sgp30.ex
+++ b/lib/sgp30.ex
@@ -74,6 +74,6 @@ defmodule Sgp30 do
   end
 
   defp log_it(str, level \\ :debug) do
-    apply(Logger, level, ["[#{__MODULE__}] - " <> str])
+    Logger.bare_log(level, ["[#{__MODULE__}] - ", str])
   end
 end


### PR DESCRIPTION
This fixes the following error:

```
iex(1)> Sgp30.start_link
{:ok, #PID<0.1234.0>}

** (EXIT from #PID<0.1231.0>) shell process exited with reason: an exception was raised:
    ** (UndefinedFunctionError) function Logger.debug/1 is undefined or private
        (logger 1.11.2) Logger.debug("[Elixir.Sgp30] - Measuring...")
```

`Logger.debug/1` changed into a macro a while back so there's no function to
call. This avoids the issue by calling `Logger.bare_log/3`.