### PR TITLE
Rename Sgp30 to SGP30

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ end
 
 According to the [datasheet](https://www.mouser.com/datasheet/2/682/Sensirion_Gas_Sensors_SGP30_Datasheet_EN-1148053.pdf), the sensor must
 be initialized and the caller must start a measurement every second.
-`Sgp30` handles this for you once initialized it will take a measurement
-every second and you would simply call `Sgp30.state` to get the
+`SGP30` handles this for you once initialized it will take a measurement
+every second and you would simply call `SGP30.state` to get the
 most current results.
 
 ```elixir
-iex()> {:ok, sgp} = Sgp30.start_link()
-iex()> Sgp30.state
-%Sgp30{
+iex()> {:ok, sgp} = SGP30.start_link()
+iex()> SGP30.state
+%SGP30{
   address: 88,
   eco2: 421,
   ethanol_raw: 17934,

--- a/lib/sgp30.ex
+++ b/lib/sgp30.ex
@@ -1,4 +1,4 @@
-defmodule Sgp30 do
+defmodule SGP30 do
   use GenServer
 
   require Logger

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Sgp30.MixProject do
+defmodule SGP30.MixProject do
   use Mix.Project
 
   @version "0.1.0"

--- a/test/sgp30_test.exs
+++ b/test/sgp30_test.exs
@@ -1,4 +1,4 @@
-defmodule Sgp30Test do
+defmodule SGP30Test do
   use ExUnit.Case
-  doctest Sgp30
+  doctest SGP30
 end


### PR DESCRIPTION
At some point, the Elixir naming convention was clarified that acronyms are to
be kept uppercase in module names. See
https://hexdocs.pm/elixir/naming-conventions.html#casing.