### PR TITLE
Add units to tvoc and co2_eq

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ iex()> {:ok, sgp} = SGP30.start_link()
 iex()> SGP30.state
 %SGP30{
   address: 88,
-  eco2: 421,
+  co2_eq_ppm: 421,
   ethanol_raw: 17934,
   h2_raw: 13113,
   i2c: #Reference<0.7390235.92137012.02842>,
   serial: <<0, 0, 0, 253, 127, 15>>,
-  tvoc: 17
+  tvoc_ppb: 17
 }
 ```
 

--- a/lib/sgp30.ex
+++ b/lib/sgp30.ex
@@ -7,7 +7,13 @@ defmodule SGP30 do
 
   @polling_interval_ms 900
 
-  defstruct address: 0x58, serial: nil, tvoc: 0, eco2: 0, i2c: nil, h2_raw: nil, ethanol_raw: nil
+  defstruct address: 0x58,
+            serial: nil,
+            tvoc_ppb: 0,
+            co2_eq_ppm: 0,
+            i2c: nil,
+            h2_raw: 0,
+            ethanol_raw: 0
 
   @spec start_link(bus_name: String.t()) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(opts \\ []) do
@@ -49,8 +55,8 @@ defmodule SGP30 do
 
     state =
       case I2C.read(i2c, address, 6) do
-        {:ok, <<eco2::size(16), _crc, tvoc::size(16), _crc2>>} ->
-          %{state | eco2: eco2, tvoc: tvoc}
+        {:ok, <<co2_eq_ppm::size(16), _crc, tvoc_ppb::size(16), _crc2>>} ->
+          %{state | co2_eq_ppm: co2_eq_ppm, tvoc_ppb: tvoc_ppb}
 
         err ->
           log_it("measure error: #{inspect(err)}", :error)


### PR DESCRIPTION
This is more of a personal preference thing, but since there are other backwards incompatible changes to the API, I figured that adding units to the VOC and CO2 measurements would be really nice.